### PR TITLE
Bump Upload Artifact to v4

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,7 +25,7 @@ jobs:
       #- run: typst compile letter.typ --font-path ./src/fonts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output
           path: ./*.pdf


### PR DESCRIPTION
> [!WARNING]
> `actions/upload-artifact@v3` was deprecated on November 30, 2024. [Learn More](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)